### PR TITLE
Create ajax

### DIFF
--- a/app/assets/javascripts/create.js
+++ b/app/assets/javascripts/create.js
@@ -28,12 +28,10 @@ $(function() {
 
 
   $("#new_message").on("submit", function(e) {
-    // preventで、元のmessages#createは呼ばないようにする
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr("action");
 
-    // Ajaxで、messages#createを呼ぶ
     $.ajax({
       url: url,
       type: "POST",
@@ -55,7 +53,7 @@ $(function() {
     .fail(function(){
       alert("メッセージを入力してください");
     })
-    // 送信後に,SENDボタンがdisabledになるのを防ぐ
+
     .always(function(){
       $('.Main__form__sendBtn').removeAttr("disabled");
     })

--- a/app/assets/javascripts/create.js
+++ b/app/assets/javascripts/create.js
@@ -1,0 +1,64 @@
+$(function() {
+  function buildPost(post) {
+    var content = post.content ?  `<p>${post.content}</p>` :  "";
+    var image = post.image.url ? `<img src="${post.image_url}" alt="${post.image}">` : "";
+    var html =
+              `<div class="Main__messages__wrapper__message">
+                <div class="Main__messages__wrapper__message__info">
+                  <div class="Main__messages__wrapper__message__info__userName">
+                    ${post.name}
+                  </div>
+                  <div class="Main__messages__wrapper__message__info__createdAt">
+                    ${post.date}
+                  </div>
+                </div>
+                <div class="Main__messages__wrapper__message__text">
+                  ${content}
+                  ${image}
+                </div>
+              </div>`
+    return html;
+  }
+
+  function appendFalshMsg(msg) {
+    var html =
+              `<div class="notice">${msg}</div>`
+    return html;
+  }
+
+
+  $("#new_message").on("submit", function(e) {
+    // preventで、元のmessages#createは呼ばないようにする
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr("action");
+
+    // Ajaxで、messages#createを呼ぶ
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(post) {
+      var html1 = buildPost(post);
+      var html2 = appendFalshMsg("メッセージが送信されました");
+      $('.Main__messages__wrapper').append(html1);
+      $('.notification').append(html2);
+      $('#message_content').val('');
+      $('.Main__messages').animate({
+        scrollTop: $('.Main__messages')[0].scrollHeight
+      }, "fast");
+    })
+    .fail(function(){
+      alert("メッセージを入力してください");
+    })
+    // 送信後に,SENDボタンがdisabledになるのを防ぐ
+    .always(function(){
+      $('.Main__form__sendBtn').removeAttr("disabled");
+    })
+  });
+
+});

--- a/app/assets/javascripts/create.js
+++ b/app/assets/javascripts/create.js
@@ -43,9 +43,10 @@ $(function() {
     .done(function(post) {
       var html1 = buildPost(post);
       var html2 = appendFalshMsg("メッセージが送信されました");
+      var form = $('#new_message')[0];
       $('.Main__messages__wrapper').append(html1);
       $('.notification').append(html2);
-      $('#message_content').val('');
+      form.reset();
       $('.Main__messages').animate({
         scrollTop: $('.Main__messages')[0].scrollHeight
       }, "fast");
@@ -53,7 +54,6 @@ $(function() {
     .fail(function(){
       alert("メッセージを入力してください");
     })
-
     .always(function(){
       $('.Main__form__sendBtn').removeAttr("disabled");
     })

--- a/app/assets/stylesheets/modules/_chat.scss
+++ b/app/assets/stylesheets/modules/_chat.scss
@@ -100,7 +100,7 @@
       }
       
     }
-    &__sendBtn input {
+    &__sendBtn {
       @include btn(100px, 50px, 0, null, #38aef0);
       background-color: #38aef0;
       color: $sidebar-white;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,7 +2,6 @@ class MessagesController < ApplicationController
   before_action :set_group
   def index
     @message = Message.new
-    # @group.messagesの個々のメッセージのuserをincludesで取得
     @messages = @group.messages.includes(:user)
   end
 

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,16 +7,14 @@ class MessagesController < ApplicationController
   end
 
   def create
-    # @group.messages.new が今ひとつ..
-    # 保存に成功した場合と失敗した場合で分岐
     @message = @group.messages.new(message_params)
-    if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
-    else
-      @messages = @group.messages.includes(:user)
-      flash.now[:alert] = 'メッセージを入力して下さい'
-      render  :index
+    @message.save
+  
+    respond_to do |format|
+      format.html
+      format.json
     end
+
   end
 
   private

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.content      @message.content
+json.name         @message.user.name
+json.image_url    @message.image.url
+json.image        @message.image
+json.date         @message.created_at.strftime("%Y/%m/%d %H:%M")

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -20,5 +20,5 @@
               = f.label :image, class: 'Main__form__textarea__icon' do
                 = fa_icon 'photo'
                 = f.file_field :image, class: 'Main__form__textarea__icon__hidden'
-        %li.Main__form__sendBtn
-          = f.submit 'Send'
+        %li
+          = f.submit 'Send', class: 'Main__form__sendBtn'


### PR DESCRIPTION
## What
- メッセージ投稿の非同期通信の実装
- イベント発生：フォームがsubmitされた時
- Ajax: formDataをPOSTにてコントローラに送信
- コントローラ: 投稿内容の保存、jbuilderに@message送信
- jbuilderからjson形式でデータをjsに送る
- jsで、jsonデータをhtmlに成形。メッセージ一覧にappend
- animateでスクロールさせる

## Why
- メッセージ投稿後に、リダイレクトせずに、メッセージ一覧が表示できるようにする。

##### 以上、レビュー宜しくお願いいたします。
![8f33553248cd0425b7856957d544c0ed](https://user-images.githubusercontent.com/45715172/61197079-ca2ef800-a70d-11e9-99b3-6f2e11d60a86.gif)

